### PR TITLE
Compression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 
 [deps]
 AbstractStorage = "14dbef02-f468-5f15-853e-5ec8dee7b899"
+Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/CloudSeis.jl
+++ b/src/CloudSeis.jl
@@ -410,7 +410,7 @@ function process_kwargs(;kwargs...)
     compressors = compressor_options()
     local compressor
     if kwargs[:compressor] == nothing
-        compressor = compressors["none"]
+        compressor = compressors["leftjustify"]
     else
         kwargs[:compressor] ∈ keys(compressors) || compressor_error()
         compressor = compressors[kwargs[:compressor]]

--- a/src/CloudSeis.jl
+++ b/src/CloudSeis.jl
@@ -883,8 +883,7 @@ Read traces from `io` into `trcs::Matrix` for the frame `idx...`.
 """
 function TeaSeis.readframetrcs!(io::CSeis, trcs::AbstractArray, idx::CartesianIndex)
     _trcs = getframetrcs(io, idx)
-    fld = fold(io, idx)
-    copyto!(trcs, 1, _trcs, 1, size(io,1)*fld)
+    copyto!(trcs, 1, _trcs, 1, size(io,1)*size(io,2))
 end
 
 """
@@ -906,8 +905,7 @@ Read headers from `io` into `hdrs::Matrix` for the frame `idx...`.
 """
 function TeaSeis.readframehdrs!(io::CSeis, hdrs::AbstractArray{UInt8,2}, idx::CartesianIndex)
     _hdrs = getframehdrs(io, idx)
-    fld = fold(io, idx)
-    copyto!(hdrs, 1, _hdrs, 1, io.hdrlength*fld)
+    copyto!(hdrs, 1, _hdrs, 1, io.hdrlength*size(io,2))
 end
 
 """
@@ -952,8 +950,8 @@ function TeaSeis.writeframe(io::CSeis, trcs::AbstractArray, hdrs::AbstractArray{
     fold!(io, fld, idx)
     _trcs = getframetrcs(io, idx)
     _hdrs = getframehdrs(io,idx)
-    copyto!(_trcs, 1, trcs, 1, fld*size(io,1))
-    copyto!(_hdrs, 1, hdrs, 1, fld*io.hdrlength)
+    copyto!(_trcs, 1, trcs, 1, size(io,2)*size(io,1))
+    copyto!(_hdrs, 1, hdrs, 1, size(io,2)*io.hdrlength)
     fld
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,12 +38,31 @@ function csopen_robust(containers, mode; kwargs...)
 end
 
 const clouds = (Azure, Azure2, POSIX)
+const compressors = ("none","blosc","leftjustify")
 
-@testset "CloudSeis, cloud=$cloud" for cloud in clouds
-    @testset "allocframe" begin
+@testset "CloudSeis, cloud=$cloud, compresser=$compressor" for cloud in clouds, compressor in compressors
+    @testset "CloudSeis, compression selection" begin
         sleep(1)
         r = lowercase(randstring(MersenneTwister(millisecond(now())+0)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
+        if compressor == "none"
+            @test isa(io.cache.compressor, CloudSeis.NotACompressor)
+            @test Dict(io.cache.compressor)["method"] == "none"
+        end
+        if compressor == "blosc"
+            @test isa(io.cache.compressor, CloudSeis.BloscCompressor)
+            @test Dict(io.cache.compressor)["method"] == "blosc"
+        end
+        if compressor == "leftjustify"
+            @test isa(io.cache.compressor, CloudSeis.LeftJustifyCompressor)
+            @test Dict(io.cache.compressor)["method"] == "leftjustify"
+        end
+    end
+
+    @testset "allocframe" begin
+        sleep(1)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+1)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
         t,h = allocframe(io)
 
         @test size(t) == (10,11)
@@ -56,35 +75,67 @@ const clouds = (Azure, Azure2, POSIX)
         rm(io)
     end
 
-    @testset "writeframe/readframe with headers" begin
+    @testset "writeframe/readframe with headers and variable fold" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+1)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+2)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
-        x = rand(Float32,10,11)
-
+        x = rand(Float32,10,11,12)
         t,h = allocframe(io)
-        t .= x
 
-        for i = 1:size(h,2)
-            set!(prop(io,io.axis_propdefs[2]), h, i, i)
-            set!(prop(io,io.axis_propdefs[3]), h, i, 1)
-            set!(prop(io,stockprop[:TRC_TYPE]), h, i, tracetype[:live])
+        n = size(h,2)
+        J = Vector{Vector{Int}}(undef, size(io,3))
+        for iframe = 1:size(io,3)
+            t .= x[:,:,iframe]
+            if iframe == 2
+                J[iframe] = [1:11;]
+            elseif iframe == 5
+                J[iframe] = Int[]
+            elseif iframe == 9
+                J[iframe] = [6]
+            else
+                J[iframe] = randperm(n)[1:div(n,2)]
+            end
+            for itrace = 1:size(io,2)
+                set!(prop(io,io.axis_propdefs[2]), h, itrace, itrace)
+                set!(prop(io,io.axis_propdefs[3]), h, itrace, iframe)
+                set!(prop(io,stockprop[:TRC_TYPE]), h, itrace, itrace ∈ J[iframe] ? tracetype[:live] : tracetype[:dead])
+                if itrace ∉ J[iframe]
+                    t[:,itrace] .= 0
+                end
+            end
+            writeframe(io,t,h)
         end
-        writeframe(io,t,h)
         close(io)
+
+        nbytes = filesize(io.extents[1].container, io.extents[1].name)
+        if compressor == "leftjustify"
+            @test nbytes == size(io,3)*8 + mapreduce(iframe->length(J[iframe])*(size(io,1)*sizeof(io.traceformat) + headerlength(io)), +, 1:size(io,3))
+        elseif compressor == "none"
+            @test nbytes == size(io,3)*8 + size(io,3)*size(io,2)*(4*size(io,1) + headerlength(io))
+        elseif compressor == "blosc"
+            @test nbytes < size(io,3)*8 + size(io,3)*size(io,2)*(4*size(io,1) + headerlength(io))
+        end
 
         io = csopen(mkcontainer(cloud, "test-$r-cs"))
-        t,h = readframe(io, 1)
-        close(io)
-        @test t ≈ x
+        for iframe = 1:size(io,3)
+            t,h = readframe(io, iframe)
+            for i = 1:size(h,2)
+                if i ∈ J[iframe]
+                    @test t[:,i] ≈ x[:,i,iframe]
+                    @test get(prop(io,io.axis_propdefs[3]), h, i) == iframe
+                end
+                @test get(prop(io,io.axis_propdefs[2]), h, i) == i
+                @test get(prop(io,stockprop[:TRC_TYPE]), h, i) == (i ∈ J[iframe] ? tracetype[:live] : tracetype[:dead])
+            end
+        end
         rm(io)
     end
 
     @testset "writeframe/readframe with index" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+2)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("P",1)])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+3)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("P",1)], compressor=compressor)
 
         x = rand(Float32,10,11)
 
@@ -103,10 +154,13 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "write" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+3)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+4)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         x = rand(Float32,10,11,12)
+        for ifrm = 1:12
+            x[:,:,ifrm] .= ifrm
+        end
         write(io, x, :, :, :)
         close(io)
 
@@ -121,8 +175,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "write, multiple extents" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+4)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], frames_per_extent=1)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+5)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], frames_per_extent=1, compressor=compressor)
 
         x = rand(Float32,10,11,12)
         write(io, x, :, :, :)
@@ -139,8 +193,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "readtrcs" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+5)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+6)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         x = rand(Float32,10,11,12)
         write(io, x, :, :, :)
@@ -156,8 +210,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "readhdrs" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+6)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+7)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         x = rand(Float32,10,11,12)
         write(io, x, :, :, :)
@@ -176,8 +230,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "readhdrs!" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+7)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+8)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         x = rand(Float32,10,11,12)
         write(io, x, :, :, :)
@@ -196,8 +250,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "partial read for foldmap" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+8)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+9)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         x = rand(Float32,10,11,12)
         write(io, x, :, :, :)
@@ -213,11 +267,12 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "similarto" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+9)))
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+10)))
         io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w",
             axis_pincs=[0.1,0.2,0.3],
             axis_lengths=[10,11,12],
-            dataproperties=[DataProperty("P",1)])
+            dataproperties=[DataProperty("P",1)],
+            compressor=compressor)
         close(io)
 
         _io = csopen_robust(mkcontainer(cloud, "test-$r-sim-cs"), "w", similarto=mkcontainer(cloud, "test-$r-cs"))
@@ -232,11 +287,12 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "similarto, changing extents" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+10)))
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+11)))
         io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w",
             axis_pincs=[0.1,0.2,0.3],
             axis_lengths=[10,11,12],
-            dataproperties=[DataProperty("P",1)])
+            dataproperties=[DataProperty("P",1)],
+            compressor=compressor)
         @test length(io.extents) == 1
         close(io)
 
@@ -251,8 +307,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "propdefs" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+11)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+12)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
         @test propdefs(io,1).label == "SAMPLE"
         @test propdefs(io,2).label == "TRACE"
         @test propdefs(io,3).label == "FRAME"
@@ -265,8 +321,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "props" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+12)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
         @test props(io,1).def.label == "SAMPLE"
         @test props(io,2).def.label == "TRACE"
         @test props(io,3).def.label == "FRAME"
@@ -279,9 +335,9 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "vector props" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+13)))
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+14)))
         pdef = TracePropertyDef("X","XX",Vector{Float64},2)
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], tracepropertydefs=[pdef])
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], tracepropertydefs=[pdef], compressor=compressor)
         t,h = allocframe(io)
         for i = 1:11
             set!(prop(io,"TRACE"), h, i, i)
@@ -304,8 +360,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "pincs" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+14)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pincs=[1.0,2.0,3.0])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+15)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pincs=[1.0,2.0,3.0], compressor=compressor)
         @test pincs(io,1) ≈ 1.0
         @test pincs(io,2) ≈ 2.0
         @test pincs(io,3) ≈ 3.0
@@ -318,8 +374,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "pstarts" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+15)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pstarts=[1.0,2.0,3.0])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+16)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pstarts=[1.0,2.0,3.0], compressor=compressor)
         @test pstarts(io,1) ≈ 1.0
         @test pstarts(io,2) ≈ 2.0
         @test pstarts(io,3) ≈ 3.0
@@ -332,8 +388,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "units" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+16)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_units=["X","Y","Z"])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+17)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_units=["X","Y","Z"], compressor=compressor)
         @test units(io,1) == "X"
         @test units(io,2) == "Y"
         @test units(io,3) == "Z"
@@ -346,8 +402,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "domains" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+17)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_domains=["X","Y","Z"])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+18)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_domains=["X","Y","Z"], compressor=compressor)
         @test domains(io,1) == "X"
         @test domains(io,2) == "Y"
         @test domains(io,3) == "Z"
@@ -368,8 +424,8 @@ const clouds = (Azure, Azure2, POSIX)
             u1=1,un=2,
             v1=3,vn=4,
             w1=5,wn=6)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+18)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], geometry=g)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+19)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], geometry=g, compressor=compressor)
 
         _g = geometry(io)
         @test g.ox ≈ 1.0
@@ -397,8 +453,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "in" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+19)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+20)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         @test in(stockprop[:TRACE], io) == true
         @test in(stockprop[:CDP],io) == false
@@ -409,8 +465,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "dataproperty" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+20)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("X",1)])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+21)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("X",1)], compressor=compressor)
 
         @test dataproperty(io, "X") == 1
 
@@ -420,8 +476,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "hasdataproperty" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+21)))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("X",1)])
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+22)))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], dataproperties=[DataProperty("X",1)], compressor=compressor)
 
         @test hasdataproperty(io, "X") == true
         @test hasdataproperty(io, "Y") == false
@@ -432,11 +488,10 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "copy!" begin
         sleep(1)
-        r1 = lowercase(randstring(MersenneTwister(millisecond(now())+22),4))
-        io1 = csopen_robust(mkcontainer(cloud, "test-$r1-cs"), "w", axis_lengths=[10,11,12])
-        sleep(1)
-        r2 = lowercase(randstring(MersenneTwister(millisecond(now())+23),4))
-        io2 = csopen_robust(mkcontainer(cloud, "test-$r2-cs"), "w", axis_lengths=[10,11,12])
+        r1 = lowercase(randstring(MersenneTwister(millisecond(now())+23),4))
+        io1 = csopen_robust(mkcontainer(cloud, "test-$r1-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
+        r2 = lowercase(randstring(MersenneTwister(millisecond(now())+24),4))
+        io2 = csopen_robust(mkcontainer(cloud, "test-$r2-cs"), "w", axis_lengths=[10,11,12], compressor=compressor)
 
         h1 = allocframehdrs(io1)
         h2 = allocframehdrs(io2)
@@ -463,8 +518,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "reduce" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+24),4))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,50], frames_per_extent=2)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+25),4))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,50], frames_per_extent=2, compressor=compressor)
 
         @test length(io.extents) == 25
 
@@ -494,8 +549,8 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "reduce, parallel" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+25),4))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,50], frames_per_extent=2)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+26),4))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,50], frames_per_extent=2, compressor=compressor)
 
         @test length(io.extents) == 25
 
@@ -528,12 +583,23 @@ const clouds = (Azure, Azure2, POSIX)
 
     @testset "robust cscreate" begin
         sleep(1)
-        r = lowercase(randstring(MersenneTwister(millisecond(now())+26),4))
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+27),4))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, compressor=compressor)
         writeframe(io, rand(Float32,10,11), 1)
         close(io)
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true)
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, compressor=compressor)
         writeframe(io, rand(Float32,10,11), 1)
         close(io)
+    end
+
+    @testset "backward compatibility (1.1->1.0)" begin
+        sleep(1)
+        r = lowercase(randstring(MersenneTwister(millisecond(now())+28),4))
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, compressor="none")
+        description = JSON.parse(read(io.containers[1], "description.json", String))
+        delete!(description, "compressor")
+        write(io.containers[1], "description.json", json(description))
+        io = csopen(mkcontainer(cloud, "test-$r-cs"), axis_lengths=[10,11,12], force=true, compressor="none")
+        @test isa(io.cache, CloudSeis.Cache{CloudSeis.NotACompressor})
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,8 @@ function csopen_robust(containers, mode; kwargs...)
     io
 end
 
-const clouds = (Azure, Azure2, POSIX)
+# const clouds = (Azure, Azure2, POSIX)
+const clouds = (POSIX,)
 const compressors = ("none","blosc","leftjustify")
 
 @testset "CloudSeis, cloud=$cloud, compresser=$compressor" for cloud in clouds, compressor in compressors
@@ -48,6 +49,12 @@ const compressors = ("none","blosc","leftjustify")
         if compressor == "none"
             @test isa(io.cache.compressor, CloudSeis.NotACompressor)
             @test Dict(io.cache.compressor)["method"] == "none"
+
+            # default compression is "leftjustify"
+            r = lowercase(randstring())
+            io_default = csopen_robust(mkcontainer(cloud, "test-$r-default-cs"), "w", axis_lengths=[10,11,12])
+            @test isa(io_default.cache.compressor, CloudSeis.LeftJustifyCompressor)
+            rm(io_default)
         end
         if compressor == "blosc"
             @test isa(io.cache.compressor, CloudSeis.BloscCompressor)
@@ -57,6 +64,7 @@ const compressors = ("none","blosc","leftjustify")
             @test isa(io.cache.compressor, CloudSeis.LeftJustifyCompressor)
             @test Dict(io.cache.compressor)["method"] == "leftjustify"
         end
+        rm(io)
     end
 
     @testset "allocframe" begin


### PR DESCRIPTION
This adds a mechanism to compress data as it is flushed to storage, and de-compressed as it is read.  The primary feature here is to add a compression layer to CloudSeis.  We also introduce two methods for compression:

1. "leftjustify"  This, in particular, targets data that is variable fold.  The live traces in a frame are packed to the front of a frame, and then then frames are packed to the front of an extent.  Then the "front" of the extent is what is written to storage.  When reading a "leftjustify"'d data-set, the data is de-compressed via the regularization of the data into the extent using the frame and trace headers of a trace to identify where in the extent they belong.

2. "blosc"  This will also help for variable fold data assuming that the dead traces are zero'd out by the user.  This uses the lossless compression in the "Blosc" library for an extent.  The Blosc compressed extent is written to storage.  Upon reading, the extent is Blosc decompressed.

The method of compression is recorded via a new field in the CloudSeis JSON file "description.json".  In particular, this JSON gets a new field "compressor".  The compressor field, then, contains information about the compression algorithm used.  For example, with "leftjustify", we have:

```
{
...
"compressor": {"method: "leftjustify"}
...
}
```

For Blosc, we have:

```
{
...
   "compressor": 
   {
        "method": "blosc",
        "library": "Blosc.jl",
        "library_version: "0.7.0",
        "library_options":
        {
            "algorithm": "blosclz",
            "level": 5,
            "shuffle": true
         }
     }
...
}
```

If `FileProperties.json` does not have a "compressor" entry, then we assume that the no compression is used.  This allows us to make this change without breaking compatability.

In order to add a new compression algorithm to CloudSeis, one would create a new type (e.g. `MyCompressor` that is an instance of `AbstractCompressor`, and implement the following methods for that type:
1.`MyCompressor(d::Dict)` - construct the compressor object from a dictionary.
2. `Dict(c::MyCompressor` - construct a dictionary from `d` such that `Dict(MyCompressor(d)) = d`
3. `copy(c::MyCompressor`)
4. `cache_from_file!(io::CSeis{T,N,MyCompressor}, extentindex) where {T,N}`  read from storage into `io.cache.data`.
5 `cache_foldmap!(io::CSeis{T,N,MyCompressor}, extentindex) where {T,N}` read from storage into `io.cache.data`, but only for the foldmap.
6. `flush(io::CSeis{T,N,MyCompressor}, extentindex) where {T,N}` flush from io.cache.data to storage.