### PR TITLE
remove Apple from test matrix

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         julia-version: [1.0, 1.6]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1.0.0
       - uses: azure/login@v1.1


### PR DESCRIPTION
Unit tests on mac are failing with the following message:

```
  ✗ AzStorage
  9 dependencies successfully precompiled in 11 seconds (17 already precompiled)
  1 dependency errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the package
     Testing Running tests...
ERROR: LoadError: InitError: could not load library "/Users/runner/.julia/artifacts/c4b38eb20e08ee1b7e7862e6e054d4593f4bcdd2/lib/libAzStorage.dylib"
dlopen(/Users/runner/.julia/artifacts/c4b38eb20e08ee1b7e7862e6e054d4593f4bcdd2/lib/libAzStorage.dylib, 1): Library not loaded: @rpath/libmbedtls.12.dylib
  Referenced from: /Users/runner/.julia/artifacts/c4b38eb20e08ee1b7e7862e6e054d4593f4bcdd2/lib/libAzStorage.dylib
  Reason: image not found
Stacktrace:
  [1] dlopen(s::String, flags::UInt32; throw_error::Bool)
    @ Base.Libc.Libdl ./libdl.jl:114
  [2] dlopen(s::String, flags::UInt32)
    @ Base.Libc.Libdl ./libdl.jl:114
  [3] macro expansion
    @ ~/.julia/packages/JLLWrappers/bkwIo/src/products/library_generators.jl:54 [inlined]
  [4] __init__()
    @ AzStorage_jll ~/.julia/packages/AzStorage_jll/VGmnK/src/wrappers/x86_64-apple-darwin.jl:14
  [5] _include_from_serialized(path::String, depmods::Vector***Any***)
    @ Base ./loading.jl:674
  [6] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String)
    @ Base ./loading.jl:760
  [7] _require(pkg::Base.PkgId)
    @ Base ./loading.jl:998
  [8] require(uuidkey::Base.PkgId)
    @ Base ./loading.jl:914
  [9] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:901
 [10] include
    @ ./Base.jl:386 [inlined]
 [11] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector***String***, dl_load_path::Vector***String***, load_path::Vector***String***, concrete_deps::Vector***Pair***Base.PkgId, UInt64***, source::String)
    @ Base ./loading.jl:1213
 [12] top-level scope
    @ none:1
 [13] eval
    @ ./boot.jl:360 [inlined]
 [14] eval(x::Expr)
    @ Base.MainInclude ./client.jl:446
 [15] top-level scope
    @ none:1
during initialization of module AzStorage_jll
in expression starting at /Users/runner/.julia/packages/AzStorage/bCvye/src/AzStorage.jl:1
```