### PR TITLE
add iterator for looping over all frames in the context

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -144,10 +144,10 @@ Write a frame.  The frame, volume, etc. indices are determined from the trace pr
 writeframe(io, trcs, hdrs)
 ```
 
-To loop over all frames in a dataset of arbitrary dimensions, use Julia's
-`CartesianIndices`:
+To loop over all frames in a dataset of arbitrary dimensions, use
+`LogicalIndices`:
 ```julia
-for idx in CartesianIndices(size(io)[3:end])
+for idx in LogicalIndices(io)
   trcs, hdrs = readframe(io, idx)
 end
 ```


### PR DESCRIPTION
before the addition of logical starts and deltas, we were relying on `CartesianIndices` for this type of iteration.  But, non-unitary starts and deltas breaks this, so we introduce our own iterator (~~`ContextIndices`~~`LinearIndices`) for looping over all frames.  ~~`ContextIndices`~~`LinearIndices` also provides a means to convert from a linear frame index to a "Data Context" index.