### PR TITLE
restrict physical delta to [1.0,Inf64)

### DIFF
--- a/src/CloudSeis.jl
+++ b/src/CloudSeis.jl
@@ -627,6 +627,11 @@ function csopen_write(containers::Vector{<:Container}, mode; kwargs...)
     axis_lstarts = length(kwargs[:axis_lstarts]) == 0 ? [1 for i=1:ndim] : kwargs[:axis_lstarts]
     axis_lincs = length(kwargs[:axis_lincs]) == 0 ? [1 for i=1:ndim] : kwargs[:axis_lincs]
 
+    if any(axis_pincs .< 1.0)
+        @warn "Warning: Physical deltas less than 1.0 are not permitted, physical delta less than 1.0 are being set to 1.0"
+        axis_pincs[findall(axis_pincs .< 1.0)] .= 1.0
+    end
+
     traceproperties = get_trace_properties(kwargs[:tracepropertydefs], axis_propdefs)
 
     traceformat = kwargs[:traceformat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,6 +444,19 @@ const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("n
         rm(io)
     end
 
+    @testset "pincs override" begin
+        r = uuid4()
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pincs=[3.0,-1.0,0.0], compressor=compressor, compressor_options=compressor_options)
+        @test pincs(io,1) ≈ 3.0
+        @test pincs(io,2) ≈ 1.0
+        @test pincs(io,3) ≈ 1.0
+        @test pincs(io)[1] ≈ 3.0
+        @test pincs(io)[2] ≈ 1.0
+        @test pincs(io)[3] ≈ 1.0
+        close(io)
+        rm(io)
+    end
+
     @testset "pstarts" begin
         r = uuid4()
         io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], axis_pstarts=[1.0,2.0,3.0], compressor=compressor, compressor_options=compressor_options)


### PR DESCRIPTION
Updated code such that if a user creates a CloudSeis data set with physical delta (pincs) less than 1.0, then those deltas are reset to 1.0 to align with SeisSpace requirements. 