### PR TITLE
Bugfix for getting foldmap of extent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudSeis"
 uuid = "a8ea0714-0c8b-51e5-9b11-67a2d82946d2"
-version = "1.19.5"
+version = "1.19.6"
 
 [deps]
 AbstractStorage = "14dbef02-f468-5f15-853e-5ec8dee7b899"

--- a/src/CloudSeis.jl
+++ b/src/CloudSeis.jl
@@ -1137,8 +1137,9 @@ function cache_from_file!(io::CSeis{T,N,NotACompressor}, extentindex, regularize
     notacompressor_cache_from_file!(io, extentindex)
 end
 
+# foldmap must be stored in the cache before calling this function
 function compressed_offsets(io::CSeis{T,N,LeftJustifyCompressor}, extentindex) where {T,N}
-    fmap = foldmap(io, extentindex)
+    fmap = foldmap_from_current_extent(io)
     nframes = length(fmap)
     _headerlength = headerlength(io)
 
@@ -1163,13 +1164,16 @@ function cache_from_file!(io::CSeis{T,N,LeftJustifyCompressor}, extentindex, reg
     if regularize
         @debug "reading and decompressing extent $extentindex..."
         t_read = @elapsed begin
-            io.cache.data = Vector{UInt8}(undef, cachesize(io, extentindex))
+            io.cache.data = Vector{UInt8}(undef, cachesize(io, extentindex))    # make space for the uncompressed data in the cache
             cdata = unsafe_wrap(Array, pointer(io.cache.data), (filesize(io.extents[extentindex].container, io.extents[extentindex].name),); own=false)
             read!(io.extents[extentindex].container, io.extents[extentindex].name, cdata)
             io.cache.data[1:length(cdata)] .= cdata
         end
-
+        
         t_decompress = @elapsed begin
+            # setting cache variable to reflect what is currently stored because they are used in compressed_offsets(), but they'll be over-written in the cache!() after this function is done.
+            io.cache.type = CACHE_ALL_LEFT_JUSTIFY # set cache type to leftjustify since the data is currently left-justified in the cache until decompressed
+            io.cache.extentindex = extentindex
             compressed_trc_offsets,compressed_hdr_offsets,fmap,nframes,_headerlength = compressed_offsets(io, extentindex)
 
             for iframe = nframes:-1:1
@@ -1180,7 +1184,7 @@ function cache_from_file!(io::CSeis{T,N,LeftJustifyCompressor}, extentindex, reg
                 copyto!(io.cache.data, hdrsoffset(io, true, extentindex, io.extents[extentindex].frameindices[iframe]), io.cache.data, compressed_hdr_offsets[iframe], fmap[iframe]*_headerlength)
             end
 
-            # regularize the indivdual frames
+            # regularize the individual frames
             for (jframe,iframe) = enumerate(io.extents[extentindex].frameindices)
                 regularize!(io, fmap[jframe], getframetrcs(io, true, extentindex, iframe), getframehdrs(io, true, extentindex, iframe))
             end
@@ -1333,8 +1337,15 @@ TeaSeis.prop(io::CSeis, _property::Symbol, _T::Type{T}) where {T} = io.traceprop
 TeaSeis.prop(io::CSeis, _property::String, _T::Type{T}) where {T} = io.traceproperties[Symbol(_property)]::TraceProperty{T}
 TeaSeis.prop(io::CSeis, _property::TracePropertyDef{T}) where {T} = prop(io, _property.label, T)
 
-function foldmap(io::CSeis, extentindex)
-    nbytes = sizeof(Int)*length(io.extents[extentindex].frameindices)
+#=
+Returns the foldmap in-place for the currently cached extent.
+If no cache is loaded, throw error
+=#
+function foldmap_from_current_extent(io::CSeis)
+    if io.cache.type == CACHE_NONE || io.cache.extentindex == 0
+        error("no cache loaded. foldmap is only available for the currently cached extent. use `cache!(io, extentindex)` to load an extent into the cache.")
+    end
+    nbytes = sizeof(Int)*length(io.extents[io.cache.extentindex].frameindices)
     reinterpret(Int, view(io.cache.data, 1:nbytes))
 end
 
@@ -1383,18 +1394,18 @@ end
 """
     foldmap(io; all=false, nasync=2048, showprogress=false)
 
-Return the foldmap for either the currently cached extent (if `all=false`)
-or the entire dataset if `all=true`.  If `all=true`, then the operation is
-performed using an asynchronous map over the extents.  The number of asynchronous
-tasks in this map is controled by `nasync`.  Use `showprogress=true` to display
-a progress bar while loading the foldmap.
+Return the foldmap for either the currently cached extent in-place (if `all=false`)
+or a copy of the entire dataset if `all=true`. Will error if no cache is loaded and
+`all=false`. If `all=true`, then the operation is performed using an asynchronous
+map over the extents.  The number of asynchronous tasks in this map is controled by
+`nasync`.  Use `showprogress=true` to display a progress bar while loading the foldmap.
 """
 function foldmap(io::CSeis; all=false, nasync=2048, showprogress=false)
     local fmap
     if all
         fmap = foldmap_all(io, nasync, showprogress)
     else
-        fmap = foldmap(io, io.cache.extentindex)
+        fmap = foldmap_from_current_extent(io)
     end
     fmap
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,11 +62,8 @@ function csopen_robust(containers, mode; kwargs...)
     io
 end
 
-# const clouds = (Azure, Azure2, POSIX)
-# const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("none","blosc","leftjustify","zfp","cvx")
-
-const clouds = (POSIX,)
-const compressors =  ("none", "leftjustify")
+const clouds = (Azure, Azure2, POSIX)
+const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("none","blosc","leftjustify","zfp","cvx")
 
 @testset "CloudSeis, cloud=$cloud, compresser=$compressor" for cloud in clouds, compressor in compressors
     if compressor == "cvx"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,8 +62,11 @@ function csopen_robust(containers, mode; kwargs...)
     io
 end
 
-const clouds = (Azure, Azure2, POSIX)
-const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("none","blosc","leftjustify","zfp","cvx")
+# const clouds = (Azure, Azure2, POSIX)
+# const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("none","blosc","leftjustify","zfp","cvx")
+
+const clouds = (POSIX,)
+const compressors =  ("none", "leftjustify")
 
 @testset "CloudSeis, cloud=$cloud, compresser=$compressor" for cloud in clouds, compressor in compressors
     if compressor == "cvx"
@@ -1243,7 +1246,7 @@ const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("n
         rm(io)
     end
 
-    @testset "partial read for foldmap with empty extents" begin
+    @testset "partial read for folds with empty extents" begin
         r = uuid4()
         io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, frames_per_extent=7, compressor=compressor, compressor_options=compressor_options)
         @test fold(io,1) == 0
@@ -1253,6 +1256,13 @@ const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("n
         @test fold(io,2) == 0
         @test fold(io,11) == 0
         @test fold(io,7) == 0
+    end
+
+    @testset "read for foldmap with no extent loaded" begin
+        r = uuid4()
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, frames_per_extent=7, compressor=compressor, compressor_options=compressor_options)
+        # check for error when cache is empty and requesting foldmap of current extent in cache
+        @test_throws ErrorException CloudSeis.foldmap(io)
     end
 
     @testset "left justify headers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1245,8 +1245,14 @@ const compressors = Sys.iswindows() ? ("none","blosc","leftjustify","zfp") : ("n
 
     @testset "partial read for foldmap with empty extents" begin
         r = uuid4()
-        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true)
+        io = csopen_robust(mkcontainer(cloud, "test-$r-cs"), "w", axis_lengths=[10,11,12], force=true, frames_per_extent=7, compressor=compressor, compressor_options=compressor_options)
         @test fold(io,1) == 0
+        @test fold(io,2) == 0
+        @test fold(io,3) == 0
+        @test fold(io,12) == 0
+        @test fold(io,2) == 0
+        @test fold(io,11) == 0
+        @test fold(io,7) == 0
     end
 
     @testset "left justify headers" begin


### PR DESCRIPTION
- Bug existed for foldmap(io, extentindex) function where extent index passed in was assumed to be the correct extent index of the cache currently stored
- Got rid of extentindex parameter in favor of using the stored extent index (io.cache.extentindex)
- Changed signature of the foldmap(io, extentindex) to foldmap_from_current_extent(io), and updated use cases in library
- foldmap(io, extentindex) is no longer exported, but it was never intended to be exported to begin with
- added unit tests that indirectly test for correct retrieval of foldmaps from different extents
- bumped version